### PR TITLE
Fix border overlap of Browse all Libraries at Home page

### DIFF
--- a/src/components/Home/Libraries.js
+++ b/src/components/Home/Libraries.js
@@ -184,7 +184,7 @@ export default function Libraries() {
                     </div>
                 </div>
 
-                <div className="col-span-7 -mt-48 sm:mt-0 relative z-10 after:absolute after:left-0 after:w-full after:-top-60 after:h-60 after:bg-gradient-to-b after:from-tan/0 after:via-tan/75 after:to-tan dark:after:from-dark/0 dark:after:via-bg/75 dark:after:to-dark sm:overflow-hidden bg-tan dark:bg-dark">
+                <div className="col-span-7 -mt-48 sm:mt-0 pl-1 relative z-10 after:absolute after:left-0 after:w-full after:-top-60 after:h-60 after:bg-gradient-to-b after:from-tan/0 after:via-tan/75 after:to-tan dark:after:from-dark/0 dark:after:via-bg/75 dark:after:to-dark sm:overflow-hidden bg-tan dark:bg-dark">
                     <h3 className="text-5xl xl:text-6xl text-center sm:text-left mb-8">
                         SDKs for <span className="text-blue">web</span> and{' '}
                         <span className="text-red dark:text-yellow">mobile</span>


### PR DESCRIPTION
## Changes

At **Home page** in **SDKs block** there's a button **Browse all libraries** which has a border, which is currently trimmed by the parent **container** `<div />`. So to fix that and make button look properly a tiny spacing inside of parent container is added.

**Before**
![image](https://github.com/user-attachments/assets/2a5bf2f9-b7cd-4de5-a624-53e9ed05d595)

**After**
![image](https://github.com/user-attachments/assets/d4f09e43-8c49-4a8e-8a96-ce00aeffa4c5)


## Checklist

- [ ] Words are spelled using American English
- [ ] Titles are in [sentence case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case)
- [ ] Feature names are in **[sentence case too]([https://apastyle.apa.org/style-grammar-guidelines/capitalization/title-case](https://apastyle.apa.org/style-grammar-guidelines/capitalization/sentence-case))**
- [ ] Use relative URLs for internal links
- [ ] If I moved a page, I added a redirect in `vercel.json`
- [ ] Remove this template if you're not going to fill it out!

## Article checklist

- [ ] I've added (at least) 3-5 internal links to this new article
- [ ] I've added keywords for this page to the rank tracker in Ahrefs
- [ ] I've checked the preview build of the article
- [ ] The date on the article is today's date
- [ ] I've added this to the relevant "Tutorials and guides" docs page (if applicable)
